### PR TITLE
Gentoo pkg-version bug fix by Dan Molik dan@d3fy.net 2015-01-17

### DIFF
--- a/cli/cw-localsys
+++ b/cli/cw-localsys
@@ -248,7 +248,7 @@ on_gentoo () {
 		if [ $? -ne 0 ]; then
 			exit 1
 		else
-			/usr/bin/eix -e "$NAME" --format '<installedversions:NAMEVERSION>' | sed -e 's,'"$NAME-"',,'
+			/usr/bin/eix -e "$NAME" --format '<installedversions:NAMEVERSION>'|grep -v '\[[0-9]*\]'|sed -e 's,'"$NAME-"',,'
 			exit 0
 		fi
 		;;
@@ -275,7 +275,7 @@ on_gentoo () {
 			exit $?
 		else
 			# specific version
-			P_VERSION=$(/usr/bin/eix -n -e "$NAME" --format '<installedversions:NAMEVERSION>' | sed -e 's,'"$NAME-"',,')
+			P_VERSION=$(/usr/bin/eix -n -e "$NAME" --format '<installedversions:NAMEVERSION>'|grep -v '\[[0-9]*\]'|sed -e 's,'"$NAME-"',,')
 			if [ "$P_VERSION" != "$VERSION" ]; then
 				/usr/bin/emerge -q "$NAME-$VERSION"
 			fi


### PR DESCRIPTION
Gentoo overlay is similar to auser added package repo, they have
become ubiquitous over the last few years. But, eix will return the
overlay location if the package comes from one, which is undefined behavior.
This patch simply matches overlay location lines and excludes them.