### PR TITLE
Gentoo install pkg version by Dan Molik <dan@d3fy.net> 2015-01-19

### DIFF
--- a/cli/cw-localsys
+++ b/cli/cw-localsys
@@ -277,7 +277,7 @@ on_gentoo () {
 			# specific version
 			P_VERSION=$(/usr/bin/eix -n -e "$NAME" --format '<installedversions:NAMEVERSION>'|grep -v '\[[0-9]*\]'|sed -e 's,'"$NAME-"',,')
 			if [ "$P_VERSION" != "$VERSION" ]; then
-				/usr/bin/emerge -q "$NAME-$VERSION"
+				/usr/bin/emerge -q \="$NAME-$VERSION"
 			fi
 			exit $?
 		fi


### PR DESCRIPTION
Noticed incorrect syntax when installing a specific version of a
package.